### PR TITLE
Make binding attribute optional

### DIFF
--- a/dhcp_leases/dhcpleases.py
+++ b/dhcp_leases/dhcpleases.py
@@ -216,7 +216,7 @@ class BaseLease(object):
         self.data = properties
         self.options = options
         self.sets = sets
-        _, self.binding_state = properties['binding'].split(' ', 1)
+        self.binding_state = properties['binding'].split(' ', 1)[1] if 'binding' in properties else None
         self._now = now
 
     @property

--- a/dhcp_leases/test_lease.py
+++ b/dhcp_leases/test_lease.py
@@ -84,6 +84,13 @@ class TestLease(TestCase):
         self.assertFalse(lease.active)
         self.assertEqual(lease.binding_state, 'free')
 
+    def test_init_no_binding(self):
+        self.lease_data.pop('binding')
+        lease = Lease("192.168.0.1", self.lease_data)
+        self.assertEqual(lease.ip, "192.168.0.1")
+        self.assertIsNone(lease.binding_state)
+        self.assertFalse(lease.active)
+
     @freeze_time("2015-07-6 8:15:0")
     def test_valid_no_starts_property(self):
         self.lease_data.pop('starts')


### PR DESCRIPTION
This PR makes the library no more fail when reading the DHCP lease file of the host-only network of VMWare Player on Windows.

It is unclear whether the binding attribute would be mandatory or not. I haven't found any references. 

Anyhow, a lease entry without binding information will not be listed as an _active_ entry.